### PR TITLE
Expiring restriction keys after their effective period has finished.

### DIFF
--- a/spec/resque-restriction/job_spec.rb
+++ b/spec/resque-restriction/job_spec.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__) + '/../spec_helper')
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
 describe Resque::Job do
   before(:each) do


### PR DESCRIPTION
- This helps keeping redis resque namespace more clean, by using redis expire command to set an expiration for the restriction key by the same period of its effectiveness.
- For example, if a job is restricted by minute, the first time that restriction key is set it will be marked to expire in 60 seconds, for a job that is restricted by hour it will be marked to expire after an hour, and so on.
