### PR TITLE
Respect Resque.inline

### DIFF
--- a/lib/resque-restriction/restriction_job.rb
+++ b/lib/resque-restriction/restriction_job.rb
@@ -20,6 +20,8 @@ module Resque
       end
 
       def before_perform_restriction(*args)
+        return if Resque.inline?
+
         keys_decremented = []
         settings.each do |period, number|
           key = redis_key(period, *args)


### PR DESCRIPTION
It doesn't make sense to restrict when Resque.inline is true

Not respecting Resque.inline makes specs fail due to "Error connecting to Redis" error, since restriction code tries to set period key which requires Redis to run.