### PR TITLE
Make restrictions compatible with ActiveJob's queue_as blocks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,79 +1,17 @@
 PATH
   remote: .
   specs:
-    resque-restriction (0.4.0)
-      activejob
-      jeweler
-      mocha
-      resque
-      rspec
+    resque-restriction (0.4.2)
+      resque (>= 1.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activejob (4.2.0)
-      activesupport (= 4.2.0)
-      globalid (>= 0.3.0)
-    activesupport (4.2.0)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
-    addressable (2.3.6)
-    builder (3.2.2)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.2.5)
-    faraday (0.9.0)
-      multipart-post (>= 1.2, < 3)
-    git (1.2.9.1)
-    github_api (0.12.4)
-      addressable (~> 2.3)
-      descendants_tracker (~> 0.0.4)
-      faraday (~> 0.8, < 0.10)
-      hashie (>= 3.4)
-      multi_json (>= 1.7.5, < 2.0)
-      nokogiri (~> 1.6.6)
-      oauth2
-    globalid (0.3.3)
-      activesupport (>= 4.1.0)
-    hashie (3.4.2)
-    highline (1.6.21)
-    i18n (0.7.0)
-    jeweler (2.0.1)
-      builder
-      bundler (>= 1.0)
-      git (>= 1.2.5)
-      github_api
-      highline (>= 1.6.15)
-      nokogiri (>= 1.5.10)
-      rake
-      rdoc
-    json (1.8.3)
-    jwt (1.0.0)
-    metaclass (0.0.4)
-    mini_portile (0.6.1)
-    minitest (5.7.0)
-    mocha (1.1.0)
-      metaclass (~> 0.0.1)
     mono_logger (1.1.0)
     multi_json (1.11.2)
-    multi_xml (0.5.5)
-    multipart-post (2.0.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (~> 1.2)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    rake (10.4.2)
-    rdoc (4.1.0)
     redis (3.2.1)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
@@ -83,26 +21,11 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
-    thread_safe (0.3.5)
     tilt (1.4.1)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
 
@@ -111,6 +34,3 @@ PLATFORMS
 
 DEPENDENCIES
   resque-restriction!
-
-BUNDLED WITH
-   1.10.3

--- a/lib/resque-restriction/restriction_job.rb
+++ b/lib/resque-restriction/restriction_job.rb
@@ -45,7 +45,7 @@ module Resque
               # reincrement the keys if one of the periods triggers DontPerform so
               # that we accurately track capacity
               keys_decremented.each {|k| Resque.redis.incrby(k, 1) }
-              Resque.push restriction_queue_name, :class => to_s, :args => args
+              Resque.push restriction_queue_name(args), :class => to_s, :args => args
               raise Resque::Job::DontPerform
             end
           else
@@ -102,7 +102,7 @@ module Resque
           break if has_restrictions
         end
         if has_restrictions
-          Resque.push restriction_queue_name, :class => to_s, :args => args
+          Resque.push restriction_queue_name(args), :class => to_s, :args => args
           return true
         else
           return false
@@ -129,8 +129,8 @@ module Resque
         self.class.on_failure_restriction(err, *self.arguments)
       end
 
-      def self.restriction_queue_name
-        queue_name = self.new.queue_name
+      def self.restriction_queue_name(args = [])
+        queue_name = self.new(*args).queue_name
         "#{Resque::Plugins::Restriction::RESTRICTION_QUEUE_PREFIX}_#{queue_name}"
       end
     end

--- a/spec/resque-restriction/restriction_job_spec.rb
+++ b/spec/resque-restriction/restriction_job_spec.rb
@@ -40,6 +40,25 @@ RSpec.describe Resque::Plugins::RestrictionJob do
     it 'concats restriction queue prefix with queue name' do
       expect(MyJob.restriction_queue_name).to eq("#{Resque::Plugins::Restriction::RESTRICTION_QUEUE_PREFIX}_awesome_queue_name")
     end
+
+    context 'when queue name is a block' do
+      let(:arguments) { [1] }
+      class MyJobWithDynamicQueueName < Resque::Plugins::RestrictionJob
+        queue_as do
+          "awesome_queue_name_with_argument_#{self.arguments.first}"
+        end
+
+        def perform(args)
+        end
+      end
+
+      it 'concats restriction queue prefix with queue name and correctly builds the queue name' do
+        expect(MyJobWithDynamicQueueName.restriction_queue_name(arguments)).to eq(
+          "#{Resque::Plugins::Restriction::RESTRICTION_QUEUE_PREFIX}_" +
+            "awesome_queue_name_with_argument_#{arguments.first}"
+        )
+      end
+    end
   end
 
   context "resque" do


### PR DESCRIPTION
In the [Active Job - Queues](http://edgeguides.rubyonrails.org/active_job_basics.html#queues) section of Rails guides there's following statement: 

> To control the queue from the job level you can pass a block to #queue_as

Without this PR it is not possible to use queue_as with block and this plugin