### PR TITLE
Reduce Redis thrashing on large restriction queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The argument of restrict method is a hash, the key of the hash is a period time,
 Advance
 -------
 
+### Custom Restrictions
+
 You can also add customized restriction as you like. For example, we have a job to restrict the facebook post numbers 40 times per user per day, we can define as:
 
 
@@ -92,6 +94,17 @@ end
 
 options["user_id"] returns the user's facebook uid, the key point is that the different restriction_identifiers can restrict different job execution numbers.
 
+### Reducing Redis Thrashing
+
+With large restriction queues (1,000+ jobs), Redis is hit with a large number of `Resque.pop` and re-enqueue calls which puts the job immediately back into the restriction queue. That process translates to extraneous Redis requests.
+
+To avoid the extraneous Redis calls, configure `max_queue_peek`. An appropriate `max_queue_peek` value depends on your application, number of workers, job processing time, and peek jobs in the queue. By default `max_queue_peek` is disabled.
+
+```ruby
+Resque::Restriction.configure do |config|
+  config.max_queue_peek = 100 # jobs
+end
+```
 
 Contributing
 ------------

--- a/lib/resque/plugins/job.rb
+++ b/lib/resque/plugins/job.rb
@@ -8,7 +8,7 @@ module Resque
           # If processing the restriction queue, when poping and pushing to end,
           # we can't tell when we reach the original one, so just walk the length
           # of the queue or up to max_queue_peek so we don't run infinitely long
-          [Resque.size(queue), Restriction.config.max_queue_peek(queue)].min.times do
+          [Resque.size(queue), Restriction.config.max_queue_peek(queue)].compact.min.times do
             # For the job at the head of the queue, repush to restricition queue
             # if still restricted, otherwise we have a runnable job, so create it
             # and return

--- a/lib/resque/plugins/job.rb
+++ b/lib/resque/plugins/job.rb
@@ -7,8 +7,8 @@ module Resque
         if queue =~ /^#{Plugins::Restriction::RESTRICTION_QUEUE_PREFIX}/
           # If processing the restriction queue, when poping and pushing to end,
           # we can't tell when we reach the original one, so just walk the length
-          # of the queue so we don't run infinitely long
-          Resque.size(queue).times do |i|
+          # of the queue or up to max_queue_peek so we don't run infinitely long
+          [Resque.size(queue), Restriction.config.max_queue_peek(queue)].min.times do
             # For the job at the head of the queue, repush to restricition queue
             # if still restricted, otherwise we have a runnable job, so create it
             # and return
@@ -19,7 +19,7 @@ module Resque
               end
             end
           end
-          return nil
+          nil
         else
           # drop through to original Job::Reserve if not restriction queue
           origin_reserve(queue)

--- a/lib/resque/restriction.rb
+++ b/lib/resque/restriction.rb
@@ -1,3 +1,4 @@
 require 'resque'
+require 'resque/restriction/config'
 require 'resque/plugins/job'
 require 'resque/plugins/restriction'

--- a/lib/resque/restriction/config.rb
+++ b/lib/resque/restriction/config.rb
@@ -1,0 +1,23 @@
+module Resque
+  module Restriction
+    def self.configure
+      yield config
+    end
+
+    def self.config
+      @config ||= Config.new
+    end
+
+    class Config
+      attr_writer :max_queue_peek
+
+      def initialize
+        @max_queue_peek = 100
+      end
+
+      def max_queue_peek(queue)
+        @max_queue_peek.respond_to?(:call) ? @max_queue_peek.call(queue) : @max_queue_peek
+      end
+    end
+  end
+end

--- a/lib/resque/restriction/config.rb
+++ b/lib/resque/restriction/config.rb
@@ -9,14 +9,40 @@ module Resque
     end
 
     class Config
-      attr_writer :max_queue_peek
-
       def initialize
-        @max_queue_peek = 100
+        @max_queue_peek = nil
+      end
+
+      def max_queue_peek=(value_or_callable)
+        if value_or_callable.respond_to?(:call)
+          @max_queue_peek = value_or_callable
+        elsif value_or_callable.nil?
+          @max_queue_peek = nil
+        else
+          @max_queue_peek = validated_max_queue_peek(value_or_callable)
+        end
       end
 
       def max_queue_peek(queue)
         @max_queue_peek.respond_to?(:call) ? @max_queue_peek.call(queue) : @max_queue_peek
+      end
+
+      private
+
+      def validated_max_queue_peek(value)
+        peek = nil
+
+        begin
+          peek = Integer(value)
+
+          if peek <= 0
+            raise ArgumentError
+          end
+        rescue ArgumentError
+          raise ArgumentError, "max_queue_peek should be either nil or an Integer greater than 0 but #{value.inspect} was provided"
+        end
+
+        peek
       end
     end
   end

--- a/resque-restriction.gemspec
+++ b/resque-restriction.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'resque', '>= 1.7.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/spec/resque/job_spec.rb
+++ b/spec/resque/job_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('../spec_helper', File.dirname(__FILE__))
 
 RSpec.describe Resque::Job do
   before(:example) do
-    Resque.redis.flushall
+    Resque.redis.redis.flushall
   end
 
   it "should repush restriction queue when reserve" do

--- a/spec/resque/plugins/restriction_spec.rb
+++ b/spec/resque/plugins/restriction_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Resque::Plugins::Restriction do
     include PerformJob
 
     before(:example) do
-      Resque.redis.flushall
+      Resque.redis.redis.flushall
     end
 
     it "should set execution number and decrement it when one job first executed" do

--- a/spec/resque/restriction/config_spec.rb
+++ b/spec/resque/restriction/config_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module Resque
+  module Restriction
+    RSpec.describe Config do
+      it 'has a default value for max_queue_peek' do
+        expect(Restriction.config.max_queue_peek('restriction_queue1')).to eq(100)
+      end
+
+      it 'can be configured with new values' do
+        Restriction.configure do |config|
+          config.max_queue_peek = 50
+        end
+        expect(Restriction.config.max_queue_peek('restriction_queue1')).to eq(50)
+      end
+
+      it 'can be configured with a lambda' do
+        Restriction.configure do |config|
+          sizes = {
+            'foo' => 10,
+            'bar' => 100
+          }
+          config.max_queue_peek = -> queue { sizes[queue] || 25 }
+        end
+        expect(Restriction.config.max_queue_peek('foo')).to eq(10)
+        expect(Restriction.config.max_queue_peek('bar')).to eq(100)
+        expect(Restriction.config.max_queue_peek('baz')).to eq(25)
+      end
+    end
+  end
+end

--- a/spec/resque/restriction/config_spec.rb
+++ b/spec/resque/restriction/config_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 module Resque
   module Restriction
     RSpec.describe Config do
-      it 'has a default value for max_queue_peek' do
-        expect(Restriction.config.max_queue_peek('restriction_queue1')).to eq(100)
+      it 'has a default of nil for max_queue_peek (disabled)' do
+        expect(Restriction.config.max_queue_peek('restriction_queue1')).to be_nil
       end
 
       it 'can be configured with new values' do
@@ -12,6 +12,22 @@ module Resque
           config.max_queue_peek = 50
         end
         expect(Restriction.config.max_queue_peek('restriction_queue1')).to eq(50)
+      end
+
+      it 'errors when given an integer less than 1' do
+        expect {
+          Restriction.configure do |config|
+            config.max_queue_peek = 0
+          end
+        }.to raise_error(ArgumentError, "max_queue_peek should be either nil or an Integer greater than 0 but 0 was provided")
+      end
+
+      it 'errors when given an non-integer' do
+        expect {
+          Restriction.configure do |config|
+            config.max_queue_peek = "abcd"
+          end
+        }.to raise_error(ArgumentError, 'max_queue_peek should be either nil or an Integer greater than 0 but "abcd" was provided')
       end
 
       it 'can be configured with a lambda' do


### PR DESCRIPTION
## Problem

With large restriction queues (1000+ jobs), Resque is hit with a large number of `Resque.pop` calls in the `Resque::Job.reserve` extension which ends up putting the job back into the restriction queue. That process translates to many extraneous Redis requests.

## Solution

Add an optional configuration to have a maximum queue peek value, `max_queue_peek`. It helps avoid the overhead of extra, necessary Redis requests.

An idea extracted from https://github.com/ZaiusInc/resque-restriction/pull/2.

### To Do

- [x] Update README with a vetted suggestion for `max_queue_peek`.