### PR TITLE
rename redis_key to resque_restriction_redis_key

### DIFF
--- a/lib/resque/plugins/restriction.rb
+++ b/lib/resque/plugins/restriction.rb
@@ -25,7 +25,7 @@ module Resque
 
         keys_decremented = []
         settings.each do |period, number|
-          key = redis_key(period, *args)
+          key = resque_restriction_redis_key(period, *args)
 
           # first try to set period key to be the total allowed for the period
           # if we get a 0 result back, the key wasn't set, so we know we are
@@ -55,7 +55,7 @@ module Resque
 
       def after_perform_restriction(*args)
         if settings[:concurrent]
-          key = redis_key(:concurrent, *args)
+          key = resque_restriction_redis_key(:concurrent, *args)
           Resque.redis.incrby(key, 1)
         end
       end
@@ -64,7 +64,7 @@ module Resque
         after_perform_restriction(*args)
       end
 
-      def redis_key(period, *args)
+      def resque_restriction_redis_key(period, *args)
         period_key, custom_key = period.to_s.split('_and_')
         period_str = case period_key.to_sym
                      when :concurrent then "*"
@@ -101,7 +101,7 @@ module Resque
       def repush(*args)
         has_restrictions = false
         settings.each do |period, number|
-          key = redis_key(period, *args)
+          key = resque_restriction_redis_key(period, *args)
           value = Resque.redis.get(key)
           has_restrictions = value && value != "" && value.to_i <= 0
           break if has_restrictions

--- a/spec/resque/job_spec.rb
+++ b/spec/resque/job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Resque::Job do
   end
 
   it "should push back to restriction queue when still restricted" do
-    Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), -1)
+    Resque.redis.set(OneHourRestrictionJob.resque_restriction_redis_key(:per_hour), -1)
     Resque.push('restriction_normal', :class => 'OneHourRestrictionJob', :args => ['any args'])
     expect(Resque::Job.reserve('restriction_normal')).to be_nil
     expect(Resque.pop('restriction_normal')).to eq({'class' => 'OneHourRestrictionJob', 'args' => ['any args']})
@@ -28,7 +28,7 @@ RSpec.describe Resque::Job do
   end
 
   it "should only push back queue_length times to restriction queue" do
-    Resque.redis.set(OneHourRestrictionJob.redis_key(:per_hour), -1)
+    Resque.redis.set(OneHourRestrictionJob.resque_restriction_redis_key(:per_hour), -1)
     3.times { Resque.push('restriction_normal', :class => 'OneHourRestrictionJob', :args => ['any args']) }
     expect(Resque.size('restriction_normal')).to eq 3
     expect(OneHourRestrictionJob).to receive(:repush).exactly(3).times.and_return(true)


### PR DESCRIPTION
I just had a fun time debugging a weird behavior when using both resque-restriction and resque-loner in the same job. It turned out both plugins use and provide an implementation for a `redis_key` method, but due to the nature of each plugin, the implementations are not compatible. resque-restriction needs the key to identify a **group** of jobs, whereas resque-loner needs the key to identify a **single** job

So... it's not exactly a bug in resque-restriction, but I thought it would be nice if each plugin uses a name that's more specific to itself. How do you like `resque_restriction_redis_key`?