### PR TITLE
Auto corrected by following Lint Ruby Lint/AmbiguousOperatorPrecedence

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ dir = File.dirname(__FILE__)
 #
 
 at_exit do
-  status_code = if $!.nil? || $!.is_a?(SystemExit) && $!.success?
+  status_code = if $!.nil? || ($!.is_a?(SystemExit) && $!.success?)
                   0
                 else
                   $!.is_a?(SystemExit) ? $!.status : 1


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/AmbiguousOperatorPrecedence

Click [here](https://awesomecode.io/repos/flyerhzm/resque-restriction/lint_configs/ruby/123739) to configure it on awesomecode.io