### PR TITLE
Auto corrected by following Lint Ruby Lint/UnusedMethodArgument

### DIFF
--- a/lib/resque/plugins/restriction.rb
+++ b/lib/resque/plugins/restriction.rb
@@ -60,7 +60,7 @@ module Resque
         end
       end
 
-      def on_failure_restriction(ex, *args)
+      def on_failure_restriction(_ex, *args)
         after_perform_restriction(*args)
       end
 
@@ -76,7 +76,7 @@ module Resque
         [RESTRICTION_QUEUE_PREFIX, self.restriction_identifier(*args), custom_value, period_str].compact.join(":")
       end
 
-      def restriction_identifier(*args)
+      def restriction_identifier(*_args)
         self.to_s
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,7 +107,7 @@ class ConcurrentRestrictionJob
 
   @queue = 'normal'
 
-  def self.perform(*args)
+  def self.perform(*_args)
     sleep 0.2
   end
 end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/UnusedMethodArgument

Click [here](https://awesomecode.io/repos/flyerhzm/resque-restriction/lint_configs/ruby/10860) to configure it on awesomecode.io